### PR TITLE
Require babel-eslint after all

### DIFF
--- a/bin/mastarm
+++ b/bin/mastarm
@@ -90,6 +90,9 @@ commander
     process.argv.push('--verbose')
     engine.cli(Object.assign({}, standard, {
       cwd: process.cwd(),
+      eslintConfig: {
+        parser: 'babel-eslint'
+      },
       homepage: 'https://github.com/conveyal/mastarm'
     }))
   })

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "test": "standard && bin/mastarm test",
+    "test": "bin/mastarm standard && bin/mastarm test",
     "cover": "bin/mastarm test --coverage --coverage-paths bin"
   },
   "repository": {
@@ -33,6 +33,7 @@
   "dependencies": {
     "aws-sdk": "^2.4.2",
     "babel-core": "^6.10.4",
+    "babel-eslint": "^7.0.0",
     "babel-jest": "^15.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-runtime": "^6.9.0",

--- a/tests/bin/mastarm.test.js
+++ b/tests/bin/mastarm.test.js
@@ -6,10 +6,19 @@ const path = require('path')
 const mastarm = path.resolve('./bin/mastarm')
 
 describe('mastarm cli', () => {
-  it('help should display', (done) => {
+  it('should display usage with no args', (done) => {
     exec(`node ${mastarm} --help`, (err, stdout, stderr) => {
       expect(err).toBeNull()
       expect(stdout).toContain('Usage: mastarm [options] [command]')
+      expect(stderr).toBe('')
+      done()
+    })
+  })
+
+  it('should run lint on a project', (done) => {
+    exec(`node ${mastarm} lint`, (err, stdout, stderr) => {
+      expect(err).toBeNull()
+      expect(stdout).toBe('')
       expect(stderr).toBe('')
       done()
     })

--- a/tests/mocks/mockComponent.js
+++ b/tests/mocks/mockComponent.js
@@ -1,0 +1,11 @@
+import {Component} from 'react'
+
+export default class MockComponent extends Component {
+  static defaultProps = {
+    test: 'hi'
+  }
+
+  render () {
+    <div />
+  }
+}


### PR DESCRIPTION
I also made a test case to prove that it is needed for static class
properties