### PR TITLE
Add .npmignore file to allow inclusion of react folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -26,9 +26,7 @@ build/Release
 
 # Dependency directory
 node_modules
-
-# Transpiled files
-/react
+yarn.lock
 
 # Optional npm cache directory
 .npm
@@ -38,3 +36,13 @@ node_modules
 
 # MacOS
 .DS_Store
+
+# tests
+tests
+
+# Continuous Integration
+.travis.yml
+
+# Docs
+README.md
+mastarm.png


### PR DESCRIPTION
Since the react folder is included as an entry in the .gitignore file, it is not published to npm.

By making a separate file for npm publishing we can ensure that the folder does get included when publishing to npm.