### PR TITLE
Fix snapshot and improve robustness

### DIFF
--- a/__tests__/lib/__snapshots__/util.js.snap
+++ b/__tests__/lib/__snapshots__/util.js.snap
@@ -1,6 +1,17 @@
 exports[`util.js parseEntries should not find any paths if no matches 1`] = `Array []`;
 
-exports[`util.js parseEntries should return inputted file paths 1`] = `Array []`;
+exports[`util.js parseEntries should return inputted file paths 1`] = `
+Array [
+  Array [
+    "__tests__/test-utils/mocks/mock.css",
+    "assets/__tests__/test-utils/mocks/mock.css",
+  ],
+  Array [
+    "__tests__/test-utils/mocks/mockComponent.js",
+    "blah",
+  ],
+]
+`;
 
 exports[`util.js parseEntries should try to find default file paths 1`] = `Array []`;
 

--- a/__tests__/lib/util.js
+++ b/__tests__/lib/util.js
@@ -5,6 +5,8 @@ jest.mock('check-dependencies', () => { return { sync: mockSyncFn } })
 jest.mock('../../lib/pkg', () => { return {} })
 
 const util = require('../../lib/util')
+const testUtils = require('../test-utils/util')
+const mockDir = testUtils.mockDir
 
 describe('util.js', () => {
   it('makeGetFn should find the right value', () => {
@@ -14,15 +16,21 @@ describe('util.js', () => {
   describe('parseEntries', () => {
     const get = () => null
     it('should try to find default file paths', () => {
-      expect(util.parseEntries([], get)).toMatchSnapshot()
+      const result = util.parseEntries([], get)
+      expect(result.length).toBe(0)
+      expect(result).toMatchSnapshot()
     })
 
     it('should not find any paths if no matches', () => {
-      expect(util.parseEntries([], get)).toMatchSnapshot()
+      const result = util.parseEntries(['fileDoesNotExist:blah'], get)
+      expect(result.length).toBe(0)
+      expect(result).toMatchSnapshot()
     })
 
     it('should return inputted file paths', () => {
-      expect(util.parseEntries(['tests/mocks/mock.css', 'tests/mocks/mockComponent.js:blah'], get)).toMatchSnapshot()
+      const result = util.parseEntries([`${mockDir}/mock.css`, `${mockDir}/mockComponent.js:blah`], get)
+      expect(result.length).toBe(2)
+      expect(result).toMatchSnapshot()
     })
   })
 
@@ -36,6 +44,7 @@ describe('util.js', () => {
   it('updateDependencies should run check-dependencies package', () => {
     const results = util.updateDependencies()
     expect(mockSyncFn).toBeCalled()
+    expect(results.status).toBe(0)
     expect(results).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
I accidentally updated a snapshot and made a test pass when it should've failed.  Therefore I added hardcoded assertions as well so that we don't 100% rely on snapshots.