### PR TITLE
Improve environment settings in test runs

### DIFF
--- a/__tests__/lib/__snapshots__/load-config.js.snap
+++ b/__tests__/lib/__snapshots__/load-config.js.snap
@@ -1,0 +1,9 @@
+exports[`load-config should work without any config files present 1`] = `
+Object {
+  "env": Object {},
+  "environment": "test",
+  "messages": Object {},
+  "settings": Object {},
+  "store": Object {},
+}
+`;

--- a/__tests__/lib/__snapshots__/test.js.snap
+++ b/__tests__/lib/__snapshots__/test.js.snap
@@ -28,5 +28,3 @@ Object {
   ],
 }
 `;
-
-exports[`test.js setupTestEnvironment should set MESSAGES environment variable if needed 1`] = `"{\"hi\":\"there\"}"`;

--- a/__tests__/lib/load-config.js
+++ b/__tests__/lib/load-config.js
@@ -1,0 +1,12 @@
+/* globals describe, expect, it */
+
+const loadConfig = require('../../lib/load-config')
+
+describe('load-config', () => {
+  it('should work without any config files present', () => {
+    const config = loadConfig(process.cwd(), '~/mastarm/configurations/default', 'test')
+    expect(config.path).toContain('mastarm/configurations/default')
+    delete config.path
+    expect(config).toMatchSnapshot()
+  })
+})

--- a/__tests__/lib/test.js
+++ b/__tests__/lib/test.js
@@ -18,9 +18,4 @@ describe('test.js', () => {
     delete jestCfg.scriptPreprocessor
     expect(jestCfg).toMatchSnapshot()
   })
-
-  it('setupTestEnvironment should set MESSAGES environment variable if needed', () => {
-    testUtils.setupTestEnvironment({ messages: { hi: 'there' } })
-    expect(process.env.MESSAGES).toMatchSnapshot()
-  })
 })

--- a/__tests__/lib/util.js
+++ b/__tests__/lib/util.js
@@ -7,6 +7,25 @@ jest.mock('../../lib/pkg', () => { return {} })
 const util = require('../../lib/util')
 
 describe('util.js', () => {
+  it('configureEnvironment should set process.env vars', () => {
+    const env2 = 'mock-env2'
+    const messages = { hi: 'there' }
+    const settings = { someSetting: true }
+    const store = {}
+    const config = {
+      env: 'mock-env',
+      path: '/made/up/path',
+      messages,
+      settings,
+      store
+    }
+    util.configureEnvironment({ config, env: env2 })
+    expect(process.env.NODE_ENV).toEqual(env2)
+    expect(JSON.parse(process.env.MESSAGES)).toEqual(messages)
+    expect(JSON.parse(process.env.SETTINGS)).toEqual(settings)
+    expect(JSON.parse(process.env.STORE)).toEqual(store)
+  })
+
   it('makeGetFn should find the right value', () => {
     expect(util.makeGetFn([{ a: 1 }, { a: 2 }])('a')).toEqual(1)
   })

--- a/bin/mastarm
+++ b/bin/mastarm
@@ -155,8 +155,9 @@ commander
     checkDependencies()
     const jest = require('jest')
     const config = loadConfig(process.cwd(), commander.config, commander.env)
+    const get = util.makeGetFn([options, commander, config.settings])
     const testUtils = require('../lib/test')
-    testUtils.setupTestEnvironment(config)
+    util.configureEnvironment({config, env: get('env')})
     jest.run(testUtils.generateTestConfig(patterns, options))
   })
 

--- a/lib/js-transform.js
+++ b/lib/js-transform.js
@@ -5,19 +5,13 @@ const through = require('through2')
 const YAML = require('yamljs')
 
 const babelConfig = require('./babel-config')
+const util = require('./util')
 
 module.exports = function transform ({
   config,
   env
 }) {
-  const defaultEnvify = Object.assign(process.env, {
-    _: 'purge',
-    CONFIG_PATH: config.path,
-    MESSAGES: JSON.stringify(config.messages),
-    NODE_ENV: env,
-    SETTINGS: JSON.stringify(config.settings),
-    STORE: JSON.stringify(config.store)
-  }, config.env)
+  util.configureEnvironment({config, env})
 
   return [
     htmlTransform,
@@ -26,7 +20,7 @@ module.exports = function transform ({
     }),
     yamlTransform,
     babelify.configure(babelConfig(env)),
-    envify(defaultEnvify) // Envify needs to happen last...
+    envify(process.env) // Envify needs to happen last...
   ]
 }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -43,9 +43,3 @@ module.exports.generateTestConfig = (patterns, options) => {
   }
   return jestArguments
 }
-
-module.exports.setupTestEnvironment = (config) => {
-  if (config.messages) {
-    process.env.MESSAGES = JSON.stringify(config.messages)
-  }
-}

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,17 @@ const path = require('path')
 
 const pkg = require('./pkg')
 
+exports.configureEnvironment = ({config, env}) => {
+  Object.assign(process.env, {
+    _: 'purge',
+    CONFIG_PATH: config.path,
+    MESSAGES: JSON.stringify(config.messages),
+    NODE_ENV: env,
+    SETTINGS: JSON.stringify(config.settings),
+    STORE: JSON.stringify(config.store)
+  }, config.env)
+}
+
 exports.makeGetFn = (targets) => {
   return (item) => {
     const ts = targets.filter((t) => t[item] !== undefined)


### PR DESCRIPTION
As I was setting up the commute settings I was trying to figure out how the settings got read into the project.  In my research I found that the test runner doesn’t read in all these settings properly.  I made this fix so that it will have the same environment setup as all js builds do.