### PR TITLE
refactor(dependency-check): Remove dependency checking. 

### DIFF
--- a/__tests__/lib/__snapshots__/util.js.snap
+++ b/__tests__/lib/__snapshots__/util.js.snap
@@ -14,10 +14,3 @@ Array [
 `;
 
 exports[`util.js parseEntries should try to find default file paths 1`] = `Array []`;
-
-exports[`util.js updateDependencies should run check-dependencies package 1`] = `
-Object {
-  "depsWereOk": true,
-  "status": 0,
-}
-`;

--- a/__tests__/lib/util.js
+++ b/__tests__/lib/util.js
@@ -1,7 +1,5 @@
 /* globals describe, expect, it, jest */
 
-const mockSyncFn = jest.fn(() => { return { status: 0, depsWereOk: true } })
-jest.mock('check-dependencies', () => { return { sync: mockSyncFn } })
 jest.mock('../../lib/pkg', () => { return {} })
 
 const util = require('../../lib/util')
@@ -39,12 +37,5 @@ describe('util.js', () => {
     expect(argv1).toContain('mastarm')
     util.popMastarmFromArgv()
     expect(process.argv[1]).not.toBe(argv1)
-  })
-
-  it('updateDependencies should run check-dependencies package', () => {
-    const results = util.updateDependencies()
-    expect(mockSyncFn).toBeCalled()
-    expect(results.status).toBe(0)
-    expect(results).toMatchSnapshot()
   })
 })

--- a/bin/mastarm
+++ b/bin/mastarm
@@ -11,7 +11,7 @@ commander
   .option('-c, --config <path>', 'Path to configuration files.', path.join(process.cwd(), '/configurations/default'))
   .option('-e, --env <environment>', 'Environment to use.', process.env.NODE_ENV || 'development')
   .option('-m, --minify', 'Minify built files.')
-  .option('-S, --skip-check-dependencies', 'Skip checking and installing out of date package.json dependencies.')
+  .option('-S, --skip-check-dependencies', '**DEPRECATED**')
 
 commander
   .command('build [entries...]')
@@ -21,7 +21,6 @@ commander
   .option('-s, --serve', 'Serve with budo. Auto-matically rebuilds on changes.')
   .option('-w, --watch', 'Automatically rebuild on changes.')
   .action(function (entries, options) {
-    checkDependencies()
     const config = loadConfig(process.cwd(), commander.config, commander.env)
     const get = util.makeGetFn([options, commander, config.settings])
     const files = util.parseEntries(entries, get)
@@ -70,7 +69,6 @@ commander
   .option('--cloudfront', 'CloudFront Distribution ID to invalidate.')
   .option('--s3bucket', 'S3 Bucket to push to.')
   .action(function (entries, options) {
-    checkDependencies()
     const pushToS3 = require('../lib/push-to-s3')
     const config = loadConfig(process.cwd(), commander.config, commander.env)
     const get = util.makeGetFn([options, commander, config.settings])
@@ -108,7 +106,6 @@ commander
   .command('prepublish [entries...]')
   .description('Transpile JavaScript down to ES5 with Babel')
   .action(function (entries, options) {
-    checkDependencies()
     const babel = require('babel-core')
     const fs = require('fs')
     const glob = require('glob')
@@ -152,7 +149,6 @@ commander
   .option('--setup-files <paths>', 'Setup files to run before each test')
   .option('--test-path-ignore-patterns <patterns>', 'File patterns to ignore when scanning for test files')
   .action(function (patterns, options) {
-    checkDependencies()
     const jest = require('jest')
     const config = loadConfig(process.cwd(), commander.config, commander.env)
     const testUtils = require('../lib/test')
@@ -161,16 +157,3 @@ commander
   })
 
 commander.parse(process.argv)
-
-function checkDependencies () {
-  if (!commander.skipCheckDependencies) {
-    const results = util.updateDependencies()
-    if (results.status !== 0) {
-      console.error(results.error)
-      process.exit(results.status)
-    } else if (!results.depsWereOk) {
-      console.log('Updated out of date dependencies found in package.json. Please try running the command again.')
-      process.exit(results.status)
-    }
-  }
-}

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,11 +54,3 @@ exports.parseEntries = function (entries, get) {
 exports.popMastarmFromArgv = function () {
   process.argv = process.argv.slice(0, 1).concat(process.argv.slice(2))
 }
-
-exports.updateDependencies = function () {
-  const checkDependenciesSync = require('check-dependencies').sync
-  return checkDependenciesSync({
-    install: true,
-    packageDir: process.cwd()
-  })
-}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "browserify": "^13.0.1",
     "browserify-markdown": "1.0.0",
     "budo": "^9.0.0",
-    "check-dependencies": "^1.0.1",
     "chokidar": "^1.6.0",
     "commander": "^2.9.0",
     "commitizen": "^2.8.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cover": "bin/mastarm test --coverage --coverage-paths bin",
     "prepublish": "rm -rf react && bin/mastarm prepublish lib/react && mv build/lib/react react && rm -rf build",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "test": "bin/mastarm standard && bin/mastarm test"
+    "test": "bin/mastarm lint && bin/mastarm test"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,16 +1144,6 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bower-config@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/bower-config/-/bower-config-1.4.0.tgz#16c38c1135f8071c19f25938d61b0d8cbf18d3f1"
-  dependencies:
-    graceful-fs "^4.1.3"
-    mout "^1.0.0"
-    optimist "^0.6.1"
-    osenv "^0.1.3"
-    untildify "^2.1.0"
-
 brace-expansion@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
@@ -1464,17 +1454,6 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3, chalk@1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-check-dependencies@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/check-dependencies/-/check-dependencies-1.0.1.tgz#9e7f15822de20621ec6b9ffaabac4d588c3811b0"
-  dependencies:
-    bower-config "^1.4.0"
-    chalk "^1.1.3"
-    findup-sync "^0.4.2"
-    lodash.camelcase "^4.3.0"
-    minimist "^1.2.0"
-    semver "^5.3.0"
 
 chokidar@^1.0.0, chokidar@^1.0.1, chokidar@^1.6.0:
   version "1.6.0"
@@ -3927,10 +3906,6 @@ lodash.assignwith@^4.0.7:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz#127a97f02adc41751a954d24b0de17e100e038eb"
 
-lodash.camelcase@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-
 lodash.clonedeep@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz#a0a1e40d82a5ea89ff5b147b8444ed63d92827db"
@@ -4258,10 +4233,6 @@ mold-source-map@~0.4.0:
   dependencies:
     convert-source-map "^1.1.0"
     through "~2.2.7"
-
-mout@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/mout/-/mout-1.0.0.tgz#9bdf1d4af57d66d47cb353a6335a3281098e1501"
 
 ms@0.7.0:
   version "0.7.0"
@@ -5656,7 +5627,7 @@ semver@^4.3.3, "semver@2 || 3 || 4":
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
 
-semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@~5.3.0, "semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5":
+semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@~5.3.0, "semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -6318,12 +6289,6 @@ uniq@^1.0.1:
 unpipe@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
-
-untildify@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/untildify/-/untildify-2.1.0.tgz#17eb2807987f76952e9c0485fc311d06a826a2e0"
-  dependencies:
-    os-homedir "^1.0.0"
 
 url-trim@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Use `"prestart": "yarn"` in scripts instead.