### PR TITLE
Add console.log output during builds

### DIFF
--- a/__tests__/bin/mastarm.js
+++ b/__tests__/bin/mastarm.js
@@ -40,7 +40,7 @@ describe('mastarm cli', () => {
       exec(`node ${mastarm} build ${mockDir}/index.js:${buildDir}/index.js ${mockDir}/index.css:${buildDir}/index.css`,
         (err, stdout, stderr) => {
           expect(err).toBeNull()
-          expect(stdout).toBe('')
+          expect(stdout).toContain('updated css file')
           expect(stderr).toBe('')
           expect(fs.existsSync(`${buildDir}/index.js`)).toBeTruthy()
           expect(fs.existsSync(`${buildDir}/index.css`)).toBeTruthy()

--- a/lib/build.js
+++ b/lib/build.js
@@ -53,6 +53,7 @@ function buildJs ({config, entry, env, minify, outfile, watch}) {
     pipeline.plugin(require('watchify'), {poll: true})
     pipeline.plugin(require('errorify'))
     pipeline.on('update', bundle)
+    pipeline.on('log', console.log)
   }
 
   return bundle()

--- a/lib/css-transform.js
+++ b/lib/css-transform.js
@@ -42,6 +42,7 @@ module.exports = function ({
           if (results.map) {
             fs.writeFile(`${outfile}.map`, results.map, handleErr)
           }
+          console.log(`updated css file: ${outfile}`)
         }
         return results
       })


### PR DESCRIPTION
* accesses the [log](https://github.com/substack/watchify#bonlog-function-msg-) event emitted by watchify
* writes whenever a css file has been written