### PR TITLE
Add no-magic-numbers plugin.

### DIFF
--- a/__tests__/bin/mastarm.js
+++ b/__tests__/bin/mastarm.js
@@ -10,11 +10,12 @@ const util = require('../test-utils/util.js')
 
 const mastarm = path.resolve(__dirname, '../../bin/mastarm')
 
+const TWENTY_SECONDS = 20000
 const originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
 
 describe('mastarm cli', () => {
   beforeEach(() => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TWENTY_SECONDS
   })
   afterEach(() => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout

--- a/__tests__/lib/babel.js
+++ b/__tests__/lib/babel.js
@@ -1,11 +1,13 @@
 /* globals describe, expect, it */
 
+const INTENDED_LENGTH = 2
+
 describe('babel', () => {
   /** As of 2016-12-15 this test fails in babel loose mode. https://github.com/babel/babel/issues/4916 */
   it('should iterate correctly over a set after using the spread operator', () => {
-    const originalArr = [1, 1, 2]
+    const originalArr = [0, 1, 1]
     const set = new Set(originalArr)
     const arr = [...set]
-    expect(arr.length).toBe(2)
+    expect(arr.length).toBe(INTENDED_LENGTH)
   })
 })

--- a/__tests__/lib/build.js
+++ b/__tests__/lib/build.js
@@ -4,41 +4,40 @@ const build = require('../../lib/build')
 const util = require('../test-utils/util.js')
 
 const originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
+const TWENTY_SECONDS = 20000
 
 describe('build', () => {
   const mockDir = util.mockDir
 
   beforeEach(() => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TWENTY_SECONDS
   })
   afterEach(() => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout
   })
 
   describe('development', () => {
-    it('should transform js', (done) => {
-      const results = build({
+    it('should transform js', () => {
+      const [jsResults] = build({
         config: {},
         files: [[`${mockDir}/index.js`]]
       })
 
-      results[0]
+      return jsResults
         .then((buf) => {
-          expect(buf.toString().indexOf('MockTestComponentUniqueName')).to.not.equal(-1)
-          done()
+          expect(buf.toString().includes('MockTestComponentUniqueName')).toBeTruthy()
         })
-        .catch(done)
     })
 
     it('should transform css', async () => {
-      const results = build({
+      const [cssResults] = build({
         config: {},
         files: [[`${mockDir}/index.css`]]
       })
 
-      const result = await results[0]
+      const result = await cssResults
       const css = result.css
-      expect(css.indexOf('criticalClass')).toBeGreaterThan(-1)
+      expect(css.includes('criticalClass')).toBeTruthy()
     })
   })
 
@@ -54,10 +53,10 @@ describe('build', () => {
         minify: true
       })
 
-      const output = await Promise.all(results)
+      const [jsOutput, cssOutput] = await Promise.all(results)
 
-      expect(output[0].toString().indexOf('MockTestComponentUniqueName')).not.toBe(-1)
-      expect(output[1].css.indexOf('criticalClass')).not.toBe(-1)
+      expect(jsOutput.toString().includes('MockTestComponentUniqueName')).toBeTruthy()
+      expect(cssOutput.css.includes('criticalClass')).toBeTruthy()
     })
   })
 })

--- a/__tests__/lib/jest.js
+++ b/__tests__/lib/jest.js
@@ -2,6 +2,9 @@
 
 const jestUtils = require('../../lib/jest')
 
+const EXPECTED_ARGUMENT_LENGTH = 8
+const JEST_CONFIG_INDEX = 4
+
 describe('test.js', () => {
   it('generateTestConfig should generate proper config', () => {
     const cfg = jestUtils.generateTestConfig(['these', 'files', 'only'], {
@@ -13,8 +16,8 @@ describe('test.js', () => {
       updateSnapshots: true
     })
     expect(cfg).toBeTruthy()
-    expect(cfg.length).toEqual(8)
-    const jestCfg = JSON.parse(cfg.splice(4, 1))
+    expect(cfg.length).toEqual(EXPECTED_ARGUMENT_LENGTH)
+    const jestCfg = JSON.parse(cfg.splice(JEST_CONFIG_INDEX, 1))
     expect(cfg).toMatchSnapshot()
     expect(jestCfg.transform['.*']).toContain('lib/jest-preprocessor.js')
     delete jestCfg.transform

--- a/__tests__/lib/util.js
+++ b/__tests__/lib/util.js
@@ -25,7 +25,7 @@ describe('util.js', () => {
   })
 
   it('makeGetFn should find the right value', () => {
-    expect(util.makeGetFn([{ a: 1 }, { a: 2 }])('a')).toEqual(1)
+    expect(util.makeGetFn([{ a: 1 }, { a: 0 }])('a')).toEqual(1)
   })
 
   describe('parseEntries', () => {
@@ -37,8 +37,9 @@ describe('util.js', () => {
     })
 
     it('should return inputted file paths', () => {
+      const NUMBER_OF_ENTRIES = 2
       const result = util.parseEntries([`${mockDir}/index.css:blah`, `${mockDir}/index.js:blah`], get)
-      expect(result.length).toBe(2)
+      expect(result.length).toBe(NUMBER_OF_ENTRIES)
       expect(result).toMatchSnapshot()
     })
   })

--- a/lib/eslintrc.json
+++ b/lib/eslintrc.json
@@ -10,7 +10,12 @@
     "flowtype-errors"
   ],
   "rules": {
-    "flowtype-errors/show-errors": 2
+    "flowtype-errors/show-errors": "error",
+    "no-magic-numbers": ["warn", {
+      "detectObjects": true,
+      "ignore": [-1, 0, 1],
+      "ignoreArrayIndexes": true
+    }]
   },
   "settings": {
     "flowtype": {

--- a/lib/flyle.js
+++ b/lib/flyle.js
@@ -6,6 +6,7 @@ const mkdirp = require('mkdirp')
 const path = require('path')
 const parse = require('url').parse
 
+const HTTP_SUCCESS_OK = 200
 const DEFAULT_CACHE_DIRECTORY = `${process.env.HOME}/.flyle`
 const DEFAULT_PNG = path.resolve(__dirname, '../mastarm.png')
 
@@ -51,7 +52,7 @@ function logAndSend ({err, res}) {
 }
 
 function sendImg ({path, res}) {
-  res.writeHead(200, {
+  res.writeHead(HTTP_SUCCESS_OK, {
     'Content-Type': 'image/png'
   })
   fs.createReadStream(path).pipe(res)

--- a/lib/util.js
+++ b/lib/util.js
@@ -40,6 +40,7 @@ exports.assertEntriesExist = function (entries) {
 /**
  * A lot of subcommands utilize exact argument lengths. Pop mastarm to handle it.
  */
+const MASTARM_INDEX = 1
 exports.popMastarmFromArgv = function () {
-  process.argv = process.argv.slice(0, 1).concat(process.argv.slice(2))
+  process.argv = process.argv.slice(0, MASTARM_INDEX).concat(process.argv.slice(MASTARM_INDEX + 1))
 }


### PR DESCRIPTION
Just a warning for now. Ignores -1, 0, 1 and array indexes. See: http://eslint.org/docs/rules/no-magic-numbers for more.

I'm not 100% sold on this, but it is eye-opening to see how many warnings crop up. I think over the long term this will create better coding practices.