### PR TITLE
Build, then deploy to fix timeout errors with s3 upload

### DIFF
--- a/lib/push-to-s3.js
+++ b/lib/push-to-s3.js
@@ -16,16 +16,20 @@ module.exports = function ({
   tag
 }) {
   const upload = createUpload({bucket: s3bucket, cloudfront, log, tag})
-  return ([entry, outfile]) => (
-    path.extname(entry) === '.js'
-    ? upload({
-      body: browserify({config, entry, env, minify}).bundle(),
-      outfile
-    })
-    : transformCss({config, entry, env, minify})
-        .then((results) =>
-          upload({body: results.css, outfile}))
-  )
+  return ([entry, outfile]) =>
+    log(`:hammer_and_wrench: ${tag} building ${outfile}`)
+      .then(() => path.extname(entry) === '.js'
+        ? new Promise((resolve, reject) =>
+          browserify({config, entry, env, minify})
+            .bundle((err, buffer) => err
+              ? reject(err)
+              : resolve(upload({body: buffer, outfile}))
+            )
+          )
+        : transformCss({config, entry, env, minify})
+            .then((results) =>
+              upload({body: results.css, outfile}))
+      )
 }
 
 const createUpload = ({bucket, cloudfront, log, tag}) =>
@@ -52,40 +56,48 @@ function upload ({
       }
     })
 
-    log(`:hammer_and_wrench: ${tag} building ${outfile} and pushing to ${bucket}`).then(() => {
-      s3object
-        .upload()
-        .send(function (err) {
-          if (err) return reject(`s3 upload to ${bucket} rejected with ${err.message}`)
-          log(`:ok_hand: ${tag} finished pushing to <${bucketUrl}/${outfile}|${bucket}/${outfile}>`).then(() => {
-            if (cloudfront) {
-              const cf = new AWS.CloudFront()
-              log(`:earth_asia: ${tag} creating cloudfront invalidation at ${outfile}`).then(() => {
-                cf.createInvalidation({
-                  DistributionId: cloudfront,
-                  InvalidationBatch: {
-                    CallerReference: uuid.v4(),
-                    Paths: {
-                      Quantity: 1,
-                      Items: [
-                        '/' + outfile
-                      ]
-                    }
+    const bytes = bytesToSize(body.byteLength || body.length)
+    const bucketLink = `<${bucketUrl}/${outfile}|${bucket}/${outfile}>`
+    log(`:satellite_antenna: ${tag} uploading to ${bucketLink} (${bytes})`)
+    s3object
+      .upload()
+      .send(function (err) {
+        if (err) return reject(`s3 upload to ${bucket} rejected with ${err.code} ${err.message}`)
+        log(`:ok_hand: ${tag} finished uploading to ${bucketLink}`).then(() => {
+          if (cloudfront) {
+            const cf = new AWS.CloudFront()
+            log(`:earth_asia: ${tag} creating cloudfront invalidation at ${outfile}`).then(() => {
+              cf.createInvalidation({
+                DistributionId: cloudfront,
+                InvalidationBatch: {
+                  CallerReference: uuid.v4(),
+                  Paths: {
+                    Quantity: 1,
+                    Items: [
+                      '/' + outfile
+                    ]
                   }
-                }, function (err) {
-                  if (err) return reject(`cf invalidation rejected with ${err.message}`)
-                  done()
-                })
+                }
+              }, function (err) {
+                if (err) return reject(`cf invalidation rejected with ${err.message}`)
+                done()
               })
-            } else {
-              done()
-            }
-          })
+            })
+          } else {
+            done()
+          }
         })
-    })
+      })
 
     function done () {
       log(`:checkered_flag: ${tag} finished with ${outfile}`).then(resolve)
     }
   })
+}
+
+function bytesToSize (bytes) {
+  const sizes = ['bytes', 'kb', 'mb', 'gb', 'tb']
+  if (bytes === 0) return '0 byte'
+  const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)))
+  return Math.round(bytes / Math.pow(1024, i), 2) + sizes[i]
 }


### PR DESCRIPTION
s3 upload was failing when passing in a readable stream created by browserify. It would begin the upload but eventually fail. Separating out the process to build, then upload fixes this problem and allows us to publish the filesize.