### PR TITLE
feat(logging): Display emoji on command line :tada:

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,3 +1,4 @@
+const nodeEmoji = require('node-emoji')
 const slack = require('./notify-slack')
 
 module.exports = function ({channel, webhook} = {}) {
@@ -6,7 +7,8 @@ module.exports = function ({channel, webhook} = {}) {
     if (webhook) {
       return slack({channel, text, webhook})
     } else {
-      return Promise.resolve(console.log(text))
+      const strippedLinks = text.replace(/<[^|>]+\|([^>]+)>/g, '$1')
+      return Promise.resolve(console.log(nodeEmoji.emojify(strippedLinks)))
     }
   }
 }

--- a/lib/push-to-s3.js
+++ b/lib/push-to-s3.js
@@ -58,7 +58,7 @@ function upload ({
 
     const bytes = bytesToSize(body.byteLength || body.length)
     const bucketLink = `<${bucketUrl}/${outfile}|${bucket}/${outfile}>`
-    log(`:satellite_antenna: ${tag} uploading to ${bucketLink} (${bytes})`)
+    log(`:airplane_departure: ${tag} uploading to ${bucketLink} (${bytes})`)
     s3object
       .upload()
       .send(function (err) {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "middleware-proxy": "^2.0.2",
     "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
+    "node-emoji": "^1.5.1",
     "postcss": "^5.0.21",
     "postcss-cssnext": "^2.6.0",
     "postcss-import": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4075,6 +4075,12 @@ netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
+node-emoji@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.5.1.tgz#fd918e412769bf8c448051238233840b2aff16a1"
+  dependencies:
+    string.prototype.codepointat "^0.2.0"
+
 node-fetch@^1.0.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
@@ -5643,6 +5649,10 @@ string-width@^2.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
+
+string.prototype.codepointat@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz#6b26e9bd3afcaa7be3b4269b526de1b82000ac78"
 
 string_decoder@~0.10.0, string_decoder@~0.10.x:
   version "0.10.31"


### PR DESCRIPTION
We have really nice emoji in slack for deploy logging, but the CLI was hard to read due to the links
and the spelled-out emoji. Now links are removed and emoji displayed on the command line when
deploying.

Before:

![image](https://cloud.githubusercontent.com/assets/566958/23928927/1ba874d2-08f9-11e7-9654-c7c3c1443c49.png)

After:

![image](https://cloud.githubusercontent.com/assets/566958/23928917/06d59e04-08f9-11e7-9e95-e65a85aeb445.png)
