### PR TITLE
Extract source maps from JavaScript on deploy

### DIFF
--- a/__tests__/lib/__snapshots__/build.js.snap
+++ b/__tests__/lib/__snapshots__/build.js.snap
@@ -2,8 +2,8 @@
 
 exports[`build development should transform css 1`] = `345`;
 
-exports[`build development should transform js 1`] = `156821`;
+exports[`build development should transform js 1`] = `157929`;
 
-exports[`build production should transform and minify js and css 1`] = `155069`;
+exports[`build production should transform and minify js and css 1`] = `156127`;
 
 exports[`build production should transform and minify js and css 2`] = `345`;

--- a/__tests__/lib/__snapshots__/build.js.snap
+++ b/__tests__/lib/__snapshots__/build.js.snap
@@ -2,8 +2,8 @@
 
 exports[`build development should transform css 1`] = `345`;
 
-exports[`build development should transform js 1`] = `157929`;
+exports[`build development should transform js 1`] = `156821`;
 
-exports[`build production should transform and minify js and css 1`] = `156127`;
+exports[`build production should transform and minify js and css 1`] = `155069`;
 
 exports[`build production should transform and minify js and css 2`] = `345`;

--- a/__tests__/lib/push-to-s3.js
+++ b/__tests__/lib/push-to-s3.js
@@ -1,7 +1,9 @@
 /* global describe, it */
 
-const BUILD_DIR = '__tests__/test-utils/tmp'
-const MOCK_DIR = '__tests__/test-utils/mocks'
+const path = require('path')
+
+const BUILD_DIR = path.join(process.cwd(), '__tests__/test-utils/tmp')
+const MOCK_DIR = path.join(process.cwd(), '__tests__/test-utils/mocks')
 
 describe('lib > push to s3', () => {
   const configPush = require('../../lib/push-to-s3')

--- a/lib/browserify.js
+++ b/lib/browserify.js
@@ -4,13 +4,15 @@ const uglifyify = require('uglifyify')
 
 const transform = require('./js-transform')
 
-module.exports = function ({
+module.exports = browserifyIt
+
+function browserifyIt ({
   config,
   entry,
   env,
   minify
 }) {
-  const pipeline = browserify(entry, {
+  return browserify(entry, {
     basedir: process.cwd(),
     cache: {},
     debug: true,
@@ -22,10 +24,10 @@ module.exports = function ({
     ],
     transform: transform({config, env})
   })
+}
 
-  if (minify) {
-    pipeline.transform(uglifyify, {global: true})
-  }
-
+module.exports.minify = function (opts) {
+  const pipeline = browserifyIt(opts)
+  pipeline.transform(uglifyify, {global: true})
   return pipeline
 }

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,10 +1,7 @@
-const fs = require('fs')
-const exorcist = require('exorcist')
-const mkdirp = require('mkdirp')
 const path = require('path')
 
-const browserify = require('./browserify')
 const buildCss = require('./css-transform')
+const buildJs = require('./js-build')
 
 /**
  * Takes a configuration object, array of file entries [entry, output], and other options.
@@ -23,37 +20,4 @@ module.exports = function ({
     path.extname(entry) === '.css'
     ? buildCss({config, entry, outfile, watch})
     : buildJs({config, entry, env, minify, outfile, watch})))
-}
-
-/**
- *
- * @return Promise
- */
-
-function buildJs ({config, entry, env, minify, outfile, watch}) {
-  const pipeline = browserify({config, entry, env, minify})
-  const bundle = () => {
-    return new Promise((resolve, reject) => {
-      const stream = pipeline.bundle((err, buf) => {
-        if (err) reject(err)
-        else resolve(buf)
-      })
-
-      if (outfile) {
-        mkdirp.sync(path.dirname(outfile))
-        stream
-          .pipe(exorcist(`${outfile}.map`))
-          .pipe(fs.createWriteStream(outfile))
-      }
-    })
-  }
-
-  if (watch) {
-    pipeline.plugin(require('watchify'), {poll: true})
-    pipeline.plugin(require('errorify'))
-    pipeline.on('update', bundle)
-    pipeline.on('log', console.log)
-  }
-
-  return bundle()
 }

--- a/lib/css-transform.js
+++ b/lib/css-transform.js
@@ -45,10 +45,10 @@ module.exports = function ({
           mkdirp.sync(path.dirname(outfile))
           fs.writeFileSync(outfile, results.css)
           if (results.map) {
-            fs.writeFile(`${outfile}.map`, results.map, handleErr)
+            fs.writeFileSync(`${outfile}.map`, results.map)
           }
-          console.log(`updated css file: ${outfile}`)
         }
+        console.log('updated css file')
         return results
       })
 
@@ -92,10 +92,4 @@ function getUrl (value) {
   const match = reg.exec(value)
   const url = match[3]
   return url
-}
-
-function handleErr (err) {
-  if (err) {
-    console.error(err.stack)
-  }
 }

--- a/lib/js-build.js
+++ b/lib/js-build.js
@@ -1,0 +1,41 @@
+const fs = require('fs')
+const exorcist = require('exorcist')
+const mkdirp = require('mkdirp')
+const path = require('path')
+
+const browserify = require('./browserify')
+
+/**
+ *
+ * @return Promise
+ */
+
+module.exports = function buildJs ({config, entry, env, minify, outfile, watch}) {
+  const pipeline = minify
+    ? browserify.minify({config, entry, env})
+    : browserify({config, entry, env})
+  const bundle = () => new Promise((resolve, reject) => {
+    if (outfile) {
+      mkdirp.sync(path.dirname(outfile))
+      pipeline.bundle()
+        .pipe(exorcist(`${outfile}.map`))
+        .pipe(fs.createWriteStream(outfile))
+        .on('error', (err) => console.error(err) && reject(err))
+        .on('finish', resolve)
+    } else {
+      pipeline.bundle((err, buf) => {
+        if (err) reject(err)
+        else resolve(buf)
+      })
+    }
+  })
+
+  if (watch) {
+    pipeline.plugin(require('watchify'), {poll: true})
+    pipeline.plugin(require('errorify'))
+    pipeline.on('update', bundle)
+    pipeline.on('log', console.log)
+  }
+
+  return bundle()
+}

--- a/lib/notify-slack.js
+++ b/lib/notify-slack.js
@@ -1,32 +1,24 @@
-const Slack = require('slack-node')
-const slack = new Slack()
+const fetch = require('isomorphic-fetch')
 
 module.exports = function notify ({
   channel,
   text,
   webhook
 }) {
-  return new Promise((resolve, reject) => {
-    try {
-      slack.setWebhook(webhook)
-      slack.webhook({channel, text}, (err, response) => {
-        if (err) {
-          onError(err)
-        } else if (response.statusCode >= 400) {
-          onError(new Error(`${response.statusCode} ${response.response}`))
-        } else {
-          resolve(response)
-        }
-      })
-    } catch (err) {
-      onError(err)
-    }
-
-    function onError (err) {
-      console.log(text)
-      console.error('Error posting to Slack webhook')
-      console.error(err)
-      resolve(err) // Always resolve to avoid logging to cause failure
-    }
+  return fetch(webhook, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      channel,
+      text
+    })
+  })
+  .then((response) => response.text())
+  .catch((err) => {
+    console.error('Error posting to Slack webhook')
+    console.error(err)
+    return err
   })
 }

--- a/lib/push-to-s3.js
+++ b/lib/push-to-s3.js
@@ -1,10 +1,11 @@
 const AWS = require('aws-sdk')
+const fs = require('fs')
 const mime = require('mime')
 const path = require('path')
 const uuid = require('uuid')
 
-const browserify = require('./browserify')
-const transformCss = require('./css-transform')
+const buildJs = require('./js-build')
+const buildCss = require('./css-transform')
 
 module.exports = function ({
   cloudfront,
@@ -19,16 +20,16 @@ module.exports = function ({
   return ([entry, outfile]) =>
     log(`:hammer_and_wrench: ${tag} building ${outfile}`)
       .then(() => path.extname(entry) === '.js'
-        ? new Promise((resolve, reject) =>
-          browserify({config, entry, env, minify})
-            .bundle((err, buffer) => err
-              ? reject(err)
-              : resolve(upload({body: buffer, outfile}))
-            )
-          )
-        : transformCss({config, entry, env, minify})
-            .then((results) =>
-              upload({body: results.css, outfile}))
+        ? buildJs({config, entry, env, minify, outfile})
+            .then((buffer) => {
+              const sourceMap = `${outfile}.map`
+              return Promise.all([
+                upload({body: fs.readFileSync(outfile), outfile}),
+                upload({body: fs.readFileSync(sourceMap), outfile: sourceMap})
+              ])
+            })
+        : buildCss({config, entry, env, minify, outfile})
+            .then((results) => upload({body: results.css, outfile}))
       )
 }
 


### PR DESCRIPTION
Source maps were not being extracted from the built JavaScript files during deployment. This fixes that and automates their upload.