### PR TITLE
Use default directory for jest caches

### DIFF
--- a/__tests__/lib/__snapshots__/jest.js.snap
+++ b/__tests__/lib/__snapshots__/jest.js.snap
@@ -1,14 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test.js generateTestConfig should generate proper config 1`] = `
+exports[`jest.js generateTestConfig should generate proper config 1`] = `
 Array [
-  "--forceExit",
   "--updateSnapshot",
   "--no-cache",
   "--runInBand",
   "--config",
   Object {
-    "cacheDirectory": "tmp",
     "collectCoverageFrom": Array [
       "lib/**/*.js",
       "bin",

--- a/__tests__/lib/jest.js
+++ b/__tests__/lib/jest.js
@@ -2,9 +2,9 @@
 
 const jestUtils = require('../../lib/jest')
 
-const JEST_CONFIG_INDEX = 5
+const JEST_CONFIG_INDEX = 4
 
-describe('test.js', () => {
+describe('jest.js', () => {
   it('generateTestConfig should generate proper config', () => {
     const cfg = jestUtils.generateTestConfig(['these', 'files', 'only'], {
       cache: false,

--- a/bin/mastarm-test
+++ b/bin/mastarm-test
@@ -25,6 +25,7 @@ commander
     '--coverage-paths <paths>',
     'Extra paths to collect code coverage from'
   )
+  .option('--force-exit', 'Force Jest to exit after all tests have completed running.')
   .option('--no-cache', 'Run Jest without cache (defaults to using cache)')
   .option('--run-in-band', 'Run all tests serially in the current process')
   .option('--setup-files <paths>', 'Setup files to run before each test')

--- a/lib/jest.js
+++ b/lib/jest.js
@@ -41,7 +41,12 @@ module.exports.generateTestConfig = (patterns, options) => {
   }
 
   // jest cli params
-  let jestArguments = ['--forceExit']
+  let jestArguments = []
+
+  if (options.forceExit) {
+    jestArguments.push('--forceExit')
+  }
+
   if (options.updateSnapshots) {
     jestArguments.push('--updateSnapshot')
   }

--- a/lib/jest.js
+++ b/lib/jest.js
@@ -4,7 +4,6 @@ const pkg = require('./pkg')
 module.exports.generateTestConfig = (patterns, options) => {
   // jest config params
   const jestConfig = {
-    cacheDirectory: 'tmp',
     collectCoverage: options.coverage,
     collectCoverageFrom: ['lib/**/*.js'],
     coverageDirectory: 'coverage',


### PR DESCRIPTION
## cacheDirectory

The current cacheDirectory is set to `tmp` within master’s jest config. This creates the directory `tmp` in the project directory which typically needs to be ignored in a .gitignore file.  The default directory is /tmp I think.  I think the only reason I was using the tmp directory initially was when I was testing out jest, but now it’s not needed and causes a headache each time a new project is started.

## forceExit

The forceExit argument sometimes surpasses console.log statements, so I made it optional.  This Jest docs note that this feature is a crutch for not properly tearing down tests:  https://facebook.github.io/jest/docs/cli.html#forceexit