### PR TITLE
Update node engine to 8 and npm to 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - '6'
+  - '8'
 before_install:
   - npm i -g codecov yarn
 install:

--- a/__tests__/lib/__snapshots__/build.js.snap
+++ b/__tests__/lib/__snapshots__/build.js.snap
@@ -2,8 +2,8 @@
 
 exports[`build development should transform css 1`] = `86`;
 
-exports[`build development should transform js 1`] = `157929`;
+exports[`build development should transform js 1`] = `153933`;
 
-exports[`build production should transform and minify js and css 1`] = `156127`;
+exports[`build production should transform and minify js and css 1`] = `152135`;
 
 exports[`build production should transform and minify js and css 2`] = `86`;

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "description": "Conveyal JavaScript development toolbelt.",
   "main": "bin/mastarm",
   "engines": {
-    "node": "6",
-    "npm": "3"
+    "node": "8",
+    "npm": "5"
   },
   "bin": {
     "mastarm": "bin/mastarm",


### PR DESCRIPTION
Node 8 comes with a host of features and will be their LTE soon. Switching over will cause a breaking change as we don't want our libraries to have mismatched versions.