### PR TITLE
Add new error rule for sorting flowtype definitions

### DIFF
--- a/lib/eslintrc.json
+++ b/lib/eslintrc.json
@@ -24,7 +24,14 @@
     "prefer-const": ["warn", {
       "destructuring": "all",
       "ignoreReadBeforeAssign": false
-    }]
+    }],
+    "flowtype/sort-keys": [
+      "error",
+      "asc", {
+        "caseSensitive": true,
+        "natural": false
+      }
+    ]
   },
   "settings": {
     "flowtype": {


### PR DESCRIPTION
This will help better organize flow type definitions.  This particular rule also comes with a fix option that makes it super easy to maintain compliance.