### PR TITLE
Use babel-env more appropriately

### DIFF
--- a/lib/babel-config.js
+++ b/lib/babel-config.js
@@ -5,7 +5,6 @@ const react = require('@babel/preset-react')
 const reactRequire = require('babel-plugin-react-require').default
 const lodash = require('babel-plugin-lodash')
 const reactDisplayName = require('@babel/plugin-transform-react-display-name')
-const transformRuntime = require('@babel/plugin-transform-runtime')
 const classProperties = require('@babel/plugin-proposal-class-properties')
 const exportFrom = require('@babel/plugin-proposal-export-namespace-from')
 
@@ -18,8 +17,7 @@ module.exports = function (env) {
     exportFrom,
     lodash,
     reactDisplayName,
-    reactRequire,
-    transformRuntime
+    reactRequire
   ]
 
   return {
@@ -29,7 +27,8 @@ module.exports = function (env) {
         babelEnv,
         {
           loose: false, // Loose mode breaks spread operator on `Set`s
-          targets: { browsers }
+          targets: { browsers },
+          useBuiltIns: 'usage'
         }
       ],
       flow,


### PR DESCRIPTION
Since we are already using babel-env we can use the `useBuiltIns` flag to include the required transform runtime. See bable-env docs for more info: https://babeljs.io/docs/en/babel-preset-env#usebuiltins