### PR TITLE
Allow instrumentation of js code

### DIFF
--- a/bin/mastarm-build
+++ b/bin/mastarm-build
@@ -19,6 +19,7 @@ commander
   .option('-e, --env <environment>', 'Environment to use.')
   .option('-F, --flyle', 'Cache and serve tiles.')
   .option('-m, --minify', 'Minify built files.')
+  .option('-i, --instrument', 'Instrument js files')
   .option('-O, --outdir <dir>', 'Publish directory', '')
   .option('-p, --proxy <address>', 'Proxy calls through to target address.')
   .option('-s, --serve', 'Serve with budo. Automatically rebuilds on changes.')
@@ -38,6 +39,7 @@ const opts = {
   env: get('env'),
   files,
   flyle: get('flyle'),
+  instrument: get('instrument'),
   minify: get('minify'),
   proxy: get('proxy'),
   watch

--- a/lib/babel-config.js
+++ b/lib/babel-config.js
@@ -7,6 +7,7 @@ const lodash = require('babel-plugin-lodash')
 const reactDisplayName = require('@babel/plugin-transform-react-display-name')
 const classProperties = require('@babel/plugin-proposal-class-properties')
 const exportFrom = require('@babel/plugin-proposal-export-namespace-from')
+const istanbul = require('babel-plugin-istanbul')
 
 const browsers = require('./constants').BROWSER_SUPPORT
 
@@ -19,6 +20,8 @@ module.exports = function (env) {
     reactDisplayName,
     reactRequire
   ]
+
+  if (env === 'instrumented') { plugins.push(istanbul) }
 
   return {
     plugins,

--- a/lib/babel-config.js
+++ b/lib/babel-config.js
@@ -11,7 +11,7 @@ const istanbul = require('babel-plugin-istanbul')
 
 const browsers = require('./constants').BROWSER_SUPPORT
 
-module.exports = function (env) {
+module.exports = function (env, instrument) {
   const plugins = [
     addExports,
     classProperties,
@@ -21,7 +21,7 @@ module.exports = function (env) {
     reactRequire
   ]
 
-  if (env === 'instrumented') { plugins.push(istanbul) }
+  if (instrument) { plugins.push(istanbul) }
 
   return {
     plugins,

--- a/lib/browserify.js
+++ b/lib/browserify.js
@@ -10,7 +10,7 @@ module.exports = browserifyIt
 /**
  * Bundle some js together with browserify
  */
-function browserifyIt ({ config, entry, env, minify }) {
+function browserifyIt ({ config, entry, env, instrument }) {
   return browserify(entry, {
     basedir: process.cwd(),
     cache: {},
@@ -21,7 +21,7 @@ function browserifyIt ({ config, entry, env, minify }) {
       path.join(__dirname, '/../node_modules'),
       path.join(process.cwd(), '/node_modules')
     ],
-    transform: transform({ config, env })
+    transform: transform({ config, env, instrument })
   })
 }
 

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -6,7 +6,7 @@ const transformCss = require('./css-transform')
 const logger = require('./logger')
 const transformJs = require('./js-transform')
 
-module.exports = function ({ config, env, files, flyle, proxy }) {
+module.exports = function ({ config, env, files, flyle, instrument, proxy }) {
   const budoOpts = {
     browserify: {
       debug: true,
@@ -16,7 +16,8 @@ module.exports = function ({ config, env, files, flyle, proxy }) {
       ],
       transform: transformJs({
         config,
-        env
+        env,
+        instrument
       })
     },
     cors: true,

--- a/lib/build.js
+++ b/lib/build.js
@@ -9,13 +9,13 @@ const buildJs = require('./js-build')
  * @return [Promise] array of Promises
  */
 
-module.exports = function ({ config, env, files, minify, watch }) {
+module.exports = function ({ config, env, files, instrument, minify, watch }) {
   return Promise.all(
     files.map(
       ([entry, outfile]) =>
         path.extname(entry) === '.css'
           ? buildCss({ config, entry, minify, outfile, watch })
-          : buildJs({ config, entry, env, minify, outfile, watch })
+          : buildJs({ config, entry, env, instrument, minify, outfile, watch })
     )
   )
 }

--- a/lib/js-build.js
+++ b/lib/js-build.js
@@ -16,13 +16,14 @@ module.exports = function buildJs ({
   config,
   entry,
   env,
+  instrument,
   minify,
   outfile,
   watch
 }) {
   const pipeline = minify
-    ? browserify.minify({ config, entry, env })
-    : browserify({ config, entry, env })
+    ? browserify.minify({ config, entry, env, instrument })
+    : browserify({ config, entry, env, instrument })
   const bundle = () =>
     new Promise((resolve, reject) => {
       if (outfile) {

--- a/lib/js-transform.js
+++ b/lib/js-transform.js
@@ -9,7 +9,7 @@ const pkg = require('../lib/pkg')
 
 const babelConfig = require('./babel-config')
 
-module.exports = function transform ({ config, env }) {
+module.exports = function transform ({ config, env, instrument }) {
   const envvars = Object.assign(
     {},
     process.env,
@@ -32,7 +32,7 @@ module.exports = function transform ({ config, env }) {
     htmlTransform,
     markdown,
     yamlTransform,
-    babelify.configure(babelConfig(env)),
+    babelify.configure(babelConfig(env, instrument)),
     [envify(envvars), { global: true }] // Envify needs to happen last...
   ]
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "babel-eslint": "^9.0.0",
     "babel-jest": "^23.4.2",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-react-require": "^3.0.0",
     "babelify": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,6 +1225,15 @@ babel-plugin-istanbul@^4.1.6:
     istanbul-lib-instrument "^1.10.1"
     test-exclude "^4.2.1"
 
+babel-plugin-istanbul@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.0.tgz#6892f529eff65a3e2d33d87dc5888ffa2ecd4a30"
+  integrity sha512-CLoXPRSUWiR8yao8bShqZUIC6qLfZVVY3X1wj+QPNXu0wfmrRRfarh1LYy+dYMVI+bDj0ghy3tuqFFRFZmL1Nw==
+  dependencies:
+    find-up "^3.0.0"
+    istanbul-lib-instrument "^3.0.0"
+    test-exclude "^5.0.0"
+
 babel-plugin-jest-hoist@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
@@ -4793,6 +4802,11 @@ istanbul-lib-coverage@^1.2.0, istanbul-lib-coverage@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz#ccf7edcd0a0bb9b8f729feeb0930470f9af664f0"
 
+istanbul-lib-coverage@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#2aee0e073ad8c5f6a0b00e0dfbf52b4667472eda"
+  integrity sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==
+
 istanbul-lib-hook@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz#bc6bf07f12a641fbf1c85391d0daa8f0aea6bf86"
@@ -4810,6 +4824,19 @@ istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.10.2:
     babylon "^6.18.0"
     istanbul-lib-coverage "^1.2.1"
     semver "^5.3.0"
+
+istanbul-lib-instrument@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz#b5f066b2a161f75788be17a9d556f40a0cf2afc9"
+  integrity sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==
+  dependencies:
+    "@babel/generator" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/template" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    istanbul-lib-coverage "^2.0.1"
+    semver "^5.5.0"
 
 istanbul-lib-report@^1.1.5:
   version "1.1.5"
@@ -9079,6 +9106,16 @@ test-exclude@^4.2.1:
     micromatch "^2.3.11"
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
+test-exclude@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.0.0.tgz#cdce7cece785e0e829cd5c2b27baf18bc583cfb7"
+  integrity sha512-bO3Lj5+qFa9YLfYW2ZcXMOV1pmQvw+KS/DpjqhyX6Y6UZ8zstpZJ+mA2ERkXfpOqhxsJlQiLeVXD3Smsrs6oLw==
+  dependencies:
+    arrify "^1.0.1"
+    minimatch "^3.0.4"
+    read-pkg-up "^4.0.0"
     require-main-filename "^1.0.1"
 
 text-extensions@^1.0.0:


### PR DESCRIPTION
This adds the option to instrument code during browserify js builds.  This works in conjunction with the e2e tests performed in datatools-ui.