### PR TITLE
Handle CSS in dependencies

### DIFF
--- a/lib/js-transform.js
+++ b/lib/js-transform.js
@@ -1,4 +1,5 @@
 const babelify = require('babelify')
+const bcss = require('browserify-css')
 const envify = require('envify/custom')
 const markdown = require('browserify-markdown')
 const commit = require('this-commit')()
@@ -33,6 +34,7 @@ module.exports = function transform ({ config, env, instrument }) {
     markdown,
     yamlTransform,
     babelify.configure(babelConfig(env, instrument)),
+    [bcss, {global: true}],
     [envify(envvars), { global: true }] // Envify needs to happen last...
   ]
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "babel-plugin-react-require": "^3.0.0",
     "babelify": "^10.0.0",
     "browserify": "^16.2.2",
+    "browserify-css": "^0.14.0",
     "browserify-markdown": "2.0.1",
     "budo": "^11.3.2",
     "caniuse-lite": "^1.0.30000885",


### PR DESCRIPTION
Use browserify-css to handle CSS files required by dependencies.

This fixes `ParseError`s resulting from JavaScript files in dependencies that import CSS:
![image](https://user-images.githubusercontent.com/960264/52381404-488cbd00-2a3f-11e9-84ec-3e2c2dcb9179.png)
