### PR TITLE
Trigger patch/micro release with README tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Node
 
-We pin mastarm to a specific version of node due to inconsistencies across installation and building when using multiple versions. *Node 8 is now required to run mastarm*. 
+We pin mastarm to a specific version of node due to inconsistencies across installation and building when using multiple versions. *Node 8 is now required to run mastarm*.
 
 ## Install
 
@@ -240,7 +240,8 @@ also pass in an arbitrary number of paths to directories or files to lint.
 
 `lint-messages` is somewhat opinionated about how messages should be used in code. They should be imported
 from a local module called `messages`, and referred to using dot notation. It will work regardless
-of whether you import the top-level messages object or named children; the following all work:
+of whether you import the top-level messages object or named children. The following import strategies
+all work:
 
     import messages from '../utils/messages'
     import msgs from './messages'


### PR DESCRIPTION
Automated dependency bumps for security in #264, #265, and #266 will not trigger a semver release.
I'm using this wording tweak in README to handle this.