### PR TITLE
Downgrade flow to 0.84.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-standard": "^4.0.0",
     "exorcist": "^1.0.1",
-    "flow-bin": "^0.94.0",
+    "flow-bin": "0.84.0",
     "flow-runtime": "^0.17.0",
     "glob": "^7.1.3",
     "isomorphic-fetch": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3989,10 +3989,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
-flow-bin@^0.94.0:
-  version "0.94.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.94.0.tgz#b5d58fe7559705b73a18229f97edfc3ab6ffffcb"
-  integrity sha512-DYF7r9CJ/AksfmmB4+q+TyLMoeQPRnqtF1Pk7KY3zgfkB/nVuA3nXyzqgsIPIvnMSiFEXQcFK4z+iPxSLckZhQ==
+flow-bin@0.84.0:
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.84.0.tgz#4cb2364c750fb37a7840524fa62456b53f64cdcb"
+  integrity sha512-ocji8eEYp+YfICsm+F6cIHUcD7v5sb0/ADEXm6gyUKdjQzmSckMrPUdZtyfP973t3YGHKliUMxMvIBHyR5LbXQ==
 
 flow-runtime@^0.17.0:
   version "0.17.0"


### PR DESCRIPTION
0.85.0 introduces a host of new flow type issues in Data Tools. This is explained in this blog post:
https://medium.com/flow-type/asking-for-required-annotations-64d4f9c1edf8

re ibi-group/datatools-ui#442