### PR TITLE
Patch release: Flow downgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Node
 
-We pin mastarm to a specific version of node due to inconsistencies across installation and building when using multiple versions. *Node 8 is now required to run mastarm*. 
+We pin mastarm to a specific version of node due to inconsistencies across installation and building when using multiple versions. *Node 8 is now required to run mastarm*.
 
 ## Install
 
@@ -240,7 +240,8 @@ also pass in an arbitrary number of paths to directories or files to lint.
 
 `lint-messages` is somewhat opinionated about how messages should be used in code. They should be imported
 from a local module called `messages`, and referred to using dot notation. It will work regardless
-of whether you import the top-level messages object or named children; the following all work:
+of whether you import the top-level messages object or named children. The following import strategies
+all work:
 
     import messages from '../utils/messages'
     import msgs from './messages'

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-standard": "^4.0.0",
     "exorcist": "^1.0.1",
-    "flow-bin": "^0.94.0",
+    "flow-bin": "0.84.0",
     "flow-runtime": "^0.17.0",
     "glob": "^7.1.3",
     "isomorphic-fetch": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3989,10 +3989,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
-flow-bin@^0.94.0:
-  version "0.94.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.94.0.tgz#b5d58fe7559705b73a18229f97edfc3ab6ffffcb"
-  integrity sha512-DYF7r9CJ/AksfmmB4+q+TyLMoeQPRnqtF1Pk7KY3zgfkB/nVuA3nXyzqgsIPIvnMSiFEXQcFK4z+iPxSLckZhQ==
+flow-bin@0.84.0:
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.84.0.tgz#4cb2364c750fb37a7840524fa62456b53f64cdcb"
+  integrity sha512-ocji8eEYp+YfICsm+F6cIHUcD7v5sb0/ADEXm6gyUKdjQzmSckMrPUdZtyfP973t3YGHKliUMxMvIBHyR5LbXQ==
 
 flow-runtime@^0.17.0:
   version "0.17.0"


### PR DESCRIPTION
Patch release to downgrade flow to 0.84.0 (to resolve Data Tools flow typing issues #269).