### PR TITLE
Allow passthrough of any jest CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Options:
   -u, --update-snapshots                  Force update of snapshots. USE WITH CAUTION.
   --coverage                              Run Jest with coverage reporting
   --coverage-paths <paths>                Extra paths to collect code coverage from
-  --json-output-file <path>               Export a json report of the tests to the path
+  --jest-cli-args <args>                  Extra arguments to pass directly to the Jest Cli. Make sure to encapsulate all extra arguments in quote
   --no-cache                              Run Jest without cache (defaults to using cache)
   --run-in-band                           Run all tests serially in the current process
   --setup-files <paths>                   Setup files to run before each test

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Options:
   -u, --update-snapshots                  Force update of snapshots. USE WITH CAUTION.
   --coverage                              Run Jest with coverage reporting
   --coverage-paths <paths>                Extra paths to collect code coverage from
+  --json-output-file <path>               Export a json report of the tests to the path
   --no-cache                              Run Jest without cache (defaults to using cache)
   --run-in-band                           Run all tests serially in the current process
   --setup-files <paths>                   Setup files to run before each test

--- a/bin/mastarm-test
+++ b/bin/mastarm-test
@@ -26,6 +26,7 @@ commander
     'Extra paths to collect code coverage from'
   )
   .option('--force-exit', 'Force Jest to exit after all tests have completed running.')
+  .option('--json-output-file <path>', 'Output Jest test results to this file')
   .option('--no-cache', 'Run Jest without cache (defaults to using cache)')
   .option('--run-in-band', 'Run all tests serially in the current process')
   .option('--setup-files <paths>', 'Setup files to run before each test')

--- a/bin/mastarm-test
+++ b/bin/mastarm-test
@@ -26,7 +26,10 @@ commander
     'Extra paths to collect code coverage from'
   )
   .option('--force-exit', 'Force Jest to exit after all tests have completed running.')
-  .option('--json-output-file <path>', 'Output Jest test results to this file')
+  .option(
+    '--jest-cli-args <args>',
+    'Extra arguments to pass directly to the Jest Cli. Make sure to encapsulate all extra arguments in quotes'
+  )
   .option('--no-cache', 'Run Jest without cache (defaults to using cache)')
   .option('--run-in-band', 'Run all tests serially in the current process')
   .option('--setup-files <paths>', 'Setup files to run before each test')

--- a/lib/jest.js
+++ b/lib/jest.js
@@ -58,11 +58,6 @@ module.exports.generateTestConfig = (patterns, options) => {
     jestArguments.push('--forceExit')
   }
 
-  if (options.jsonOutputFile) {
-    jestArguments.push('--json')
-    jestArguments.push(`--outputFile=${options.jsonOutputFile}`)
-  }
-
   if (options.updateSnapshots) {
     jestArguments.push('--updateSnapshot')
   }
@@ -76,6 +71,10 @@ module.exports.generateTestConfig = (patterns, options) => {
   }
 
   jestArguments.push('--config', JSON.stringify(jestConfig))
+
+  if (options.jestCliArgs) {
+    jestArguments = jestArguments.concat(...options.jestCliArgs.split(' '))
+  }
 
   if (patterns) {
     jestArguments = jestArguments.concat(patterns)

--- a/lib/jest.js
+++ b/lib/jest.js
@@ -58,6 +58,11 @@ module.exports.generateTestConfig = (patterns, options) => {
     jestArguments.push('--forceExit')
   }
 
+  if (options.jsonOutputFile) {
+    jestArguments.push('--json')
+    jestArguments.push(`--outputFile=${options.jsonOutputFile}`)
+  }
+
   if (options.updateSnapshots) {
     jestArguments.push('--updateSnapshot')
   }


### PR DESCRIPTION
This change allows for the output of a test run to a specified json file.