### PR TITLE
Log deployments to MS Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ SLACK_CHANNEL: '#devops'
 SLACK_WEBHOOK: https://hooks.slack.com/services/fake-code
 ```
 
+#### MS Teams Notifications
+
+To enable an MS Teams notification upon the completion (successful or not) of the deploy process, create a [MS Teams Webhook](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/connectors/connectors-using#setting-up-a-custom-incoming-webhook) and add the incoming webhook url as the `MS_TEAMS_WEBHOOK` key/value to your `env.yml`.
+
+```
+MS_TEAMS_WEBHOOK: https://outlook.office.com/webhook/123...abc
+```
+
 ### `flow`
 
 Run [Flow](https://flow.org/). Must have a `.flowconfig` in the current working directory and a `// @flow` annotation at the top of each file you want to check. See the Flow website for documentation.

--- a/bin/mastarm-deploy
+++ b/bin/mastarm-deploy
@@ -89,6 +89,7 @@ logger
           .log(
             `:tada: :confetti_ball: :tada: *deploy ${tag} complete* :tada: :confetti_ball: :tada:`
           )
+          .then(() => logToMsTeams())
           .then(() => process.exit(0))
       )
       .catch(err =>
@@ -96,6 +97,44 @@ logger
           .log(
             `:rotating_light: *${tag} error deploying ${tag} ${err.message || err}*`
           )
+          .then(() => logToMsTeams(err))
           .then(() => process.exit(1))
       )
   )
+
+/**
+ * Sends a card to MS Teams with information about the deployment
+ * @param  {[Error]} error the error, if one occurred. A falsy value indicates
+ *                          success
+ */
+function logToMsTeams (error) {
+  if (!config.env.MS_TEAMS_WEBHOOK) return Promise.resolve()
+
+  const potentialAction = [{
+    '@type': 'OpenUri',
+    name: `View Commit on Github`,
+    targets: [
+      {
+        os: 'default',
+        uri: `${url}/commit/${commit}`
+      }
+    ]
+  }]
+  const text = `📄 *commit:* ${pkg.name}@${commit.slice(0, 6)}\n
+  👤 *deployed by:* ${username.sync()}\n
+  🚦 *mastarm:* v${mastarmVersion}\n
+  ☁️ *cloudfront:* ${cloudfront}\n
+  🌱 *env:* ${env}\n
+  🗜️ *minify:* ${minify}\n
+  📦 *s3bucket:* ${s3bucket}\n
+  ${error
+    ? `🚨 🚨 *error deploying ${error.message || error}*`
+    : `🎉 🎊 🎉 *deploy successful!* 🎉 🎊 🎉`}`
+
+  return logger.notifyMsTeams({
+    potentialAction,
+    text,
+    title: `${error ? 'Failed to deploy' : 'Successfully deployed'} ${pkg.name}`,
+    webhook: config.env.MS_TEAMS_WEBHOOK
+  })
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -48,3 +48,37 @@ function notifySlack ({ channel, text, webhook }) {
       return err
     })
 }
+
+/**
+ * Send a message to MS Teams using a webhook. This will generate a card
+ * according to the following schema:
+ * https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#openuri-action
+ *
+ * @param  {Array} potentialAction  An array of potential actions on a card.
+ * @param  {String} text  The card body text
+ * @param  {String} [themeColor='0072C6'] Card theme color
+ * @param  {String} title  Title of the card
+ * @param  {String} webhook  Webhook url
+ */
+module.exports.notifyMsTeams = function notifyMSTeams ({
+  potentialAction,
+  text,
+  themeColor = '0072C6',
+  title,
+  webhook
+}) {
+  return fetch(
+    webhook,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        '@context': 'https://schema.org/extensions',
+        '@type': 'MessageCard',
+        themeColor,
+        title,
+        text,
+        potentialAction
+      })
+    }
+  )
+}


### PR DESCRIPTION
Adds the ability to log deployments to MS Teams. Configure an incoming webhook in MS Teams (or use an existing one) and then add it to the env.yml file that is being used during the build to deploy.