### PR TITLE
Disable nesting checks for jsx-a11y/label-has-for

### DIFF
--- a/lib/eslintrc.json
+++ b/lib/eslintrc.json
@@ -23,6 +23,7 @@
     "import/order": ["warn", {
       "newlines-between": "always"
     }],
+    // turn off nesting requirement. See https://github.com/conveyal/mastarm/pull/296
     "jsx-a11y/label-has-for": [
       2,
       {

--- a/lib/eslintrc.json
+++ b/lib/eslintrc.json
@@ -23,6 +23,16 @@
     "import/order": ["warn", {
       "newlines-between": "always"
     }],
+    "jsx-a11y/label-has-for": [
+      2,
+      {
+        "components": [ "Label" ],
+        "required": {
+            "every": [ "id" ]
+        },
+        "allowChildren": false
+      }
+    ],
     "object-curly-spacing": 0,
     "prefer-const": ["warn", {
       "destructuring": "all",


### PR DESCRIPTION
**Important note: This PR is for merging directly to master!**

Why is this a PR directly to master? Because #295 upgraded a whole bunch of eslint packages to new major versions which introduced thousands of (in my opinion good) linting errors that will eventually make our code more standardized. When we eventually merge `dev` to master to create the next master release we should bump it up to another major version to reflect this change.

As asked in https://github.com/ibi-group/datatools-ui/pull/508, I went ahead and updated the code to pass all the jsx/a11y tests. However, [a certain case of the `label-has-associated-control` rule](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md#case-my-label-and-input-components-are-custom-components) requires manually changing your jsx/a11y to recognize custom components. Therefore, I went ahead and just disabled the nesting part of that rule.