### PR TITLE
updated deploy to take in alternative aws profile

### DIFF
--- a/bin/mastarm-deploy
+++ b/bin/mastarm-deploy
@@ -27,6 +27,7 @@ commander
   .option('-e, --env <environment>', 'Environment to use.')
   .option('-m, --minify', 'Minify built files.')
   .option('-O, --outdir <dir>', 'Publish directory', '')
+  .option('-c, --credProfile <dir>', 'Alternative AWS Credentials in .aws dir defaults to "default"', '')
   .option('--cloudfront <id>', 'CloudFront Distribution ID to invalidate.')
   .option('--s3bucket <bucket>', 'S3 Bucket to push to.')
   .option('--static-file-directory <dir>', 'Directory of static files to deploy in lieu of building')
@@ -34,7 +35,7 @@ commander
 
 // each of these variables are also used in the logToMsTeams function and
 // these need to be defined after potentially decoding a sops-encoded file
-let cloudfront, config, env, minify, s3bucket, tag, url
+let cloudfront, config, env, minify, s3bucket, tag, url, credProfile
 
 async function deploy () {
   // get information about the directory that the config is in
@@ -89,6 +90,7 @@ async function deploy () {
   minify = get('minify')
   cloudfront = get('cloudfront')
   s3bucket = get('s3bucket')
+  credProfile = get('cred') || 'default'
 
   const pushToS3 = createPushToS3({
     cloudfront,

--- a/lib/push-to-s3.js
+++ b/lib/push-to-s3.js
@@ -4,15 +4,17 @@ const uuid = require('uuid')
 
 const logger = require('./logger')
 
-module.exports = ({ s3bucket, cloudfront }) => ({ body, outfile }) =>
-  upload({ body, cloudfront, outfile, s3bucket })
+module.exports = ({ s3bucket, cloudfront, credProfile }) => ({ body, outfile }) =>
+  upload({ body, cloudfront, outfile, s3bucket, credProfile })
 
 /**
+ * 
  * Upload the contents of a file to s3.
  * Also, invalidate the respective cloudfront path if instructed to do so.
  */
 function upload ({ body, s3bucket, cloudfront, outfile }) {
   const bucketUrl = `https://s3.amazonaws.com/${s3bucket}`
+  const credentials = new AWS.SharedIniFileCredentials({profile: credProfile});
   return new Promise((resolve, reject) => {
     const s3object = new AWS.S3({
       params: {
@@ -23,6 +25,7 @@ function upload ({ body, s3bucket, cloudfront, outfile }) {
         Key: outfile
       }
     })
+    s3bucket.credentials = credentials
 
     const bytes = bytesToSize(body.byteLength || body.length)
     const bucketLink = `<${bucketUrl}/${outfile}|${s3bucket}/${outfile}>`
@@ -38,6 +41,7 @@ function upload ({ body, s3bucket, cloudfront, outfile }) {
       }
       if (cloudfront) {
         const cf = new AWS.CloudFront()
+        cf.credentials = credentials
         logger
           .log(`:lightning: *cloudfront:* invalidating path ${outfile}`)
           .then(() => {


### PR DESCRIPTION
Addressing issue #283 
This is an attempt to add support to allow multiple profiles in deployment. The solution that I put together does not allow for the copying an pasting of credentials nor a local import of json file, but simply picks out an alternative profile in the .aws/credentials file. This is best practice anyway and will help prevent accidental publication of local files that may contain keys. This pull request only addresses the 'deploy' command. If this method is acceptable I could take a look at other areas where it may be used.

AWS Credential Doc -> https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html
