### PR TITLE
Make sure node-ci runs on commits to master

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,6 +1,10 @@
 name: Node.js CI
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test-build-release:


### PR DESCRIPTION
This PR fixes the Github actions script so that it'll run whenever a commit is pushed to master. cc @binh-dam-ibigroup